### PR TITLE
Check if tmp table exists before creating it

### DIFF
--- a/models/table.rb
+++ b/models/table.rb
@@ -137,7 +137,7 @@ class Table < ActiveRecord::Base
           logger.info "Loading #{source_name} data to Redshift"
 
           temp_table_name = "stage_#{job_id}_#{source_name}"
-          destination_connection.execute("CREATE TEMP TABLE #{temp_table_name} (LIKE #{destination_name});")
+          destination_connection.execute("CREATE TEMP TABLE IF NOT EXISTS #{temp_table_name} (LIKE #{destination_name});")
 
           copy_results_to_table(temp_table_name, result)
           merge_results(temp_table_name, merge_to_table_name)


### PR DESCRIPTION
We're seeing some jobs try and create a duplicate table.
https://sentry.io/organizations/38-degrees/issues/2444192065/?project=5797288&query=is%3Aunresolved

Chose between dropping the table at the beginning or doing the check.

We already do the table check in full_sync_table#pre_copy_steps

having the check will mean any data will get copied over, job finishes
table gets dropped
if we drop the table early I would worry we would lose data